### PR TITLE
Expose prebuilt package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ethjs-util",
   "version": "0.1.4",
   "description": "A simple set of Ethereum JS utilties.",
-  "main": "lib/index.js",
+  "main": "dist/ethjs-util.min.js",
   "files": [
     "dist",
     "internals",


### PR DESCRIPTION
Exposing prebuilt package so it can be used without `babel` in other projects. (or at least without a global transform)